### PR TITLE
set Apple bundle identifier

### DIFF
--- a/bridge/main_darwin.go
+++ b/bridge/main_darwin.go
@@ -1,9 +1,24 @@
 package bridge
 
-import "github.com/progrium/macdriver/cocoa"
+import (
+	"github.com/progrium/macdriver/cocoa"
+	"github.com/progrium/macdriver/core"
+	"github.com/progrium/macdriver/objc"
+)
 
 func Main() {
 	app := cocoa.NSApp()
+	nsbundleMain := cocoa.NSBundle_Main()
+	nsbundle := nsbundleMain.Class()
+	nsbundle.AddMethod("__bundleIdentifier", func(self objc.Object) objc.Object {
+		if self.Pointer() == nsbundleMain.Pointer() {
+			return core.String("com.progrium.shellbridge")
+		}
+		// After the swizzle this will point to the original method, and return the
+		// original bundle identifier.
+		return self.Send("__bundleIdentifier")
+	})
+	nsbundle.Swizzle("bundleIdentifier", "__bundleIdentifier")
 	app.SetActivationPolicy(cocoa.NSApplicationActivationPolicyAccessory)
 	app.ActivateIgnoringOtherApps(true)
 	app.Run()

--- a/cmd/shellbridge/main.go
+++ b/cmd/shellbridge/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/progrium/shelldriver/bridge"
 )
 
-const Version = "0.2.0"
+const Version = "0.2.1"
 
 func init() {
 	runtime.LockOSThread()


### PR DESCRIPTION
When creating WKWebView instances, opening the inspector can trigger the
same type of crash described in webview/webview#627. The error is
triggered when the app is missing a bundle identifier. This provides a
default bundle identifier to prevent this error.
